### PR TITLE
Story1-HtmlTemps

### DIFF
--- a/Case/FileMover.cs
+++ b/Case/FileMover.cs
@@ -14,20 +14,23 @@ namespace PluckList
         public void Move(int index)
         {
             Directory.CreateDirectory("print");
-            var htmlName = Path.Combine("print", $"{Directory.GetFiles("print").Length + 1}.html");
-            var html = Path.Combine("templates", "PRINT-WELCOME.html");
-            
             var fileStream = File.OpenRead(_files[index]);
             var xmlSerializer = new XmlSerializer(typeof(PluckList));
             var pluckList = (PluckList?)xmlSerializer.Deserialize(fileStream);
             fileStream.Close();
 
+            var printItem = pluckList?.Lines.FirstOrDefault(item => item.Type == ItemType.Print);
+            if (pluckList == null || printItem == null) return;
+            
+            var htmlPath = Path.Combine("print", $"{Directory.GetFiles("print").Length + 1}.html");
+            var templatePath = Path.Combine("templates", $"{printItem.ProductID}.html");
+
             var vars = new Dictionary<string, string>();
-            vars.Add("Name", pluckList.Name);
-            vars.Add("Adresse", pluckList.Address);
+            vars.Add("Name", pluckList.Name!);
+            vars.Add("Adresse", pluckList.Address!);
             vars.Add("Plukliste",
                 string.Join($"<br>{Environment.NewLine}", pluckList.Lines.Select(item => $"{item.Title} (x{item.Amount})")));
-            File.WriteAllText(htmlName, HTMLTemplate.Load(html)?.GetContents(vars) ?? string.Empty);
+            File.WriteAllText(htmlPath, HTMLTemplate.Load(templatePath)?.GetContents(vars) ?? string.Empty);
             
             Directory.CreateDirectory("import");
 

--- a/Case/FileMover.cs
+++ b/Case/FileMover.cs
@@ -1,6 +1,4 @@
-﻿using System.Xml.Serialization;
-
-namespace PluckList
+﻿namespace PluckList
 {
     public class FileMover
     {
@@ -13,25 +11,18 @@ namespace PluckList
         
         public void Move(int index)
         {
+            // HTML templates
             Directory.CreateDirectory("print");
-            var fileStream = File.OpenRead(_files[index]);
-            var xmlSerializer = new XmlSerializer(typeof(PluckList));
-            var pluckList = (PluckList?)xmlSerializer.Deserialize(fileStream);
-            fileStream.Close();
-
-            var printItem = pluckList?.Lines.FirstOrDefault(item => item.Type == ItemType.Print);
+            
+            var pluckList = PluckList.Deserialize(_files[index]);
+            var printItem = pluckList?.GetPrintItem();
             if (pluckList == null || printItem == null) return;
             
             var htmlPath = Path.Combine("print", $"{Directory.GetFiles("print").Length + 1}.html");
             var templatePath = Path.Combine("templates", $"{printItem.ProductID}.html");
-
-            var vars = new Dictionary<string, string>();
-            vars.Add("Name", pluckList.Name!);
-            vars.Add("Adresse", pluckList.Address!);
-            vars.Add("Plukliste",
-                string.Join($"<br>{Environment.NewLine}", pluckList.Lines.Select(item => $"{item.Title} (x{item.Amount})")));
-            File.WriteAllText(htmlPath, HTMLTemplate.Load(templatePath)?.GetContents(vars) ?? string.Empty);
+            HTMLTemplate.Load(templatePath)?.Write(htmlPath, pluckList);
             
+            // Import
             Directory.CreateDirectory("import");
 
             var fileName = Path.GetFileName(_files[index]);

--- a/Case/FileMover.cs
+++ b/Case/FileMover.cs
@@ -1,4 +1,6 @@
-﻿namespace PluckList
+﻿using System.Xml.Serialization;
+
+namespace PluckList
 {
     public class FileMover
     {
@@ -11,9 +13,25 @@
         
         public void Move(int index)
         {
+            Directory.CreateDirectory("print");
+            var htmlName = Path.Combine("print", $"{Directory.GetFiles("print").Length + 1}.html");
+            var html = Path.Combine("templates", "PRINT-WELCOME.html");
+            
+            var fileStream = File.OpenRead(_files[index]);
+            var xmlSerializer = new XmlSerializer(typeof(PluckList));
+            var pluckList = (PluckList?)xmlSerializer.Deserialize(fileStream);
+            fileStream.Close();
+
+            var vars = new Dictionary<string, string>();
+            vars.Add("Name", pluckList.Name);
+            vars.Add("Adresse", pluckList.Address);
+            vars.Add("Plukliste",
+                string.Join($"<br>{Environment.NewLine}", pluckList.Lines.Select(item => $"{item.Title} (x{item.Amount})")));
+            File.WriteAllText(htmlName, HTMLTemplate.Load(html)?.GetContents(vars) ?? string.Empty);
+            
             Directory.CreateDirectory("import");
 
-            var fileName = Path.GetFileName(_files[0]);
+            var fileName = Path.GetFileName(_files[index]);
             File.Move(_files[index], string.Format(@"import\\{0}", fileName), true);
 
             Console.WriteLine($"Plukseddel {_files[index]} afsluttet.");

--- a/Case/HTMLTemplate.cs
+++ b/Case/HTMLTemplate.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.RegularExpressions;
+
+namespace PluckList;
+
+public partial class HTMLTemplate
+{
+    private readonly string _contents;
+    private readonly IEnumerable<string> _variables;
+    
+    private HTMLTemplate(string contents)
+    {
+        _contents = contents;
+        var matches = VariablePattern().Matches(contents);
+        _variables = matches.Select(match => match.Groups[1].Value);
+    }
+
+    public IEnumerable<string> GetVariables()
+    {
+        return _variables;
+    }
+
+    public string GetContents()
+    {
+        return _contents;
+    }
+    
+    public string GetContents(Dictionary<string, string> variables)
+    {
+        var commonVariables = _variables.Where(variables.ContainsKey);
+        return commonVariables.Aggregate(_contents,
+            (contents, variable) => contents.Replace($"[{variable}]", variables[variable]));
+    }
+
+    public static HTMLTemplate? Load(string path)
+    {
+        if (!File.Exists(path)) return null;
+        var contents = File.ReadAllText(path);
+        var template = new HTMLTemplate(contents);
+        return template;
+    }
+
+    [GeneratedRegex(@"\[(.*?)\]")]
+    private static partial Regex VariablePattern();
+}

--- a/Case/HTMLTemplate.cs
+++ b/Case/HTMLTemplate.cs
@@ -31,6 +31,24 @@ public partial class HTMLTemplate
             (contents, variable) => contents.Replace($"[{variable}]", variables[variable]));
     }
 
+    public void Write(string filePath, PluckList pluckList)
+    {
+        var printItem = pluckList.GetPrintItem();
+        if (printItem == null) throw new ArgumentException("No print item found");
+
+        var vars = new Dictionary<string, string>
+        {
+            { "Name", pluckList.Name! },
+            { "Adresse", pluckList.Address! },
+            {
+                "Plukliste",
+                string.Join($"<br>{Environment.NewLine}",
+                    pluckList.Lines.Select(item => $"{item.Title} (x{item.Amount})"))
+            },
+        };
+        File.WriteAllText(filePath, GetContents(vars));
+    }
+
     public static HTMLTemplate? Load(string path)
     {
         if (!File.Exists(path)) return null;

--- a/Case/PluckList.cs
+++ b/Case/PluckList.cs
@@ -1,4 +1,6 @@
-﻿namespace PluckList;
+﻿using System.Xml.Serialization;
+
+namespace PluckList;
 public class PluckList
 {
     public string? Name { get; set; }
@@ -6,6 +8,17 @@ public class PluckList
     public string? Address { get; set; }
     public List<Item> Lines = new List<Item>();
 
+    public Item? GetPrintItem()
+    {
+        return Lines.FirstOrDefault(item => item.Type == ItemType.Print);
+    }
+
+    public static PluckList? Deserialize(string filePath)
+    {
+        using var fileStream = File.OpenRead(filePath);
+        var xmlSerializer = new XmlSerializer(typeof(PluckList));
+        return (PluckList?)xmlSerializer.Deserialize(fileStream);
+    }
 
     //public void AddItem(Item item)
     //{

--- a/Case/PluckList.csproj
+++ b/Case/PluckList.csproj
@@ -11,6 +11,9 @@
     <None Update="export\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="templates\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Case/Printer/ConsolePrinter.cs
+++ b/Case/Printer/ConsolePrinter.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PluckList
+namespace PluckList.Printer
 {
     public abstract class ConsolePrinter : IPrint
     {

--- a/Case/Printer/FileInfoPrinter.cs
+++ b/Case/Printer/FileInfoPrinter.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PluckList
+namespace PluckList.Printer
 {
     public class FileInfoPrinter : ConsolePrinter
     {

--- a/Case/Printer/IPrint.cs
+++ b/Case/Printer/IPrint.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PluckList
+namespace PluckList.Printer
 {
     public interface IPrint
     {

--- a/Case/Printer/OptionPrinter.cs
+++ b/Case/Printer/OptionPrinter.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PluckList
+namespace PluckList.Printer
 {
     public class OptionPrinter : ConsolePrinter
     {

--- a/Case/Printer/PluckListPrinter.cs
+++ b/Case/Printer/PluckListPrinter.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace PluckList
+namespace PluckList.Printer
 {
     public class PluckListPrinter : ConsolePrinter
     {

--- a/Case/Program.cs
+++ b/Case/Program.cs
@@ -1,5 +1,7 @@
 ﻿
 //Eksempel på funktionel kodning hvor der kun bliver brugt et model lag
+using PluckList.Printer;
+
 namespace PluckList;
 
 class Program
@@ -73,6 +75,7 @@ class Program
             // Takes input
             readKey = Console.ReadKey().KeyChar;
             readKey = char.ToUpper(readKey);
+            Console.Clear();
 
             // Handles input
             colorHandle.Handle(ColorContext.Status);

--- a/Case/Program.cs
+++ b/Case/Program.cs
@@ -1,5 +1,7 @@
 ﻿
 //Eksempel på funktionel kodning hvor der kun bliver brugt et model lag
+
+using System.Diagnostics;
 using PluckList.Printer;
 
 namespace PluckList;
@@ -24,6 +26,7 @@ class Program
         
         char readKey = ' ';
         int index = -1;
+        PluckList? pluckList = null;
         
 
         // Program loop
@@ -46,7 +49,7 @@ class Program
 
                 // Serializes xml contents to plucklist
                 using var fileStream = fileReader.ReadSingle(index, files);
-                PluckList pluckList = fileReader.SerializeXmlTo<PluckList>(fileStream);
+                pluckList = fileReader.SerializeXmlTo<PluckList>(fileStream);
 
                 // Prints properties from plucklist
                 pluckListPrinter = new PluckListPrinter(pluckList);
@@ -71,6 +74,7 @@ class Program
                 optionPrinter.Print("Næste plukseddel");
             }
             optionPrinter.Print("Genindlæs plukseddel");
+            optionPrinter.Print("Åbn i browser");
 
             // Takes input
             readKey = Console.ReadKey().KeyChar;
@@ -114,6 +118,23 @@ class Program
                     {
                         index--;
                     }
+                    break;
+                case 'Å':
+                    var printItem = pluckList?.Lines.FirstOrDefault(item => item.Type == ItemType.Print);
+                    if (pluckList == null || printItem == null) break;
+                    var vars = new Dictionary<string, string>();
+                    vars.Add("Name", pluckList.Name!);
+                    vars.Add("Adresse", pluckList.Address!);
+                    vars.Add("Plukliste",
+                        string.Join($"<br>{Environment.NewLine}", pluckList.Lines.Select(item => $"{item.Title} (x{item.Amount})")));
+                    var filePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.html");
+                    var templatePath = Path.Combine("templates", $"{printItem.ProductID}.html");
+                    File.WriteAllText(filePath, HTMLTemplate.Load(templatePath)?.GetContents(vars) ?? string.Empty);
+                    var info = new ProcessStartInfo(filePath)
+                    {
+                        UseShellExecute = true
+                    };
+                    Process.Start(info);
                     break;
             }
 

--- a/Case/io/CSVWriter.cs
+++ b/Case/io/CSVWriter.cs
@@ -1,0 +1,22 @@
+﻿namespace PluckList;
+
+public class CSVWriter<T> : FileWriter
+{
+    public CSVWriter(string filePath) : base(filePath)
+    {
+    }
+
+    public void Write(IEnumerable<T> content)
+    {
+        var fields = typeof(T).GetFields();
+        var elements = content as T[] ?? content.ToArray();
+        var contents = new string[elements.Length + 1];
+        contents[0] = string.Join(",", fields.Select(field => field.Name));
+        for (var i = 0; i < elements.Length; i++)
+        {
+            var element = elements[i];
+            contents[i + 1] = string.Join(",", fields.Select(field => field.GetValue(element)));
+        }
+        File.WriteAllLines(FilePath, contents);
+    }
+}

--- a/Case/io/FileWriter.cs
+++ b/Case/io/FileWriter.cs
@@ -1,0 +1,16 @@
+﻿namespace PluckList;
+
+public class FileWriter : IContentWriter
+{
+    protected readonly string FilePath;
+    
+    public FileWriter(string filePath)
+    {
+        FilePath = filePath;
+    }
+    
+    public virtual void Write(string content)
+    {
+        File.WriteAllText(FilePath, content);
+    }
+}

--- a/Case/io/IContentWriter.cs
+++ b/Case/io/IContentWriter.cs
@@ -1,0 +1,6 @@
+﻿namespace PluckList;
+
+public interface IContentWriter
+{
+    void Write(string content);
+}

--- a/Case/templates/PRINT-OPGRADE.html
+++ b/Case/templates/PRINT-OPGRADE.html
@@ -1,0 +1,21 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Ny hurtigere forbindelse</title>
+</head>
+<body>
+    <div class="Adresse">[Adresse]</div>
+    <h1>Hurtigere forbindelse</h1>
+    <h2>Hej [Name]</h2>
+    <p>Vi er glade for give dig endnu hurtigere internet og TV-signal. Du skal tilslutte et rutrum arcu pulvinar a. Vestibulum vitae elit metus. Aliquam porttitor dui eu dui gravida tincidunt. Maecenas auctor elit enim, sed fermentum ante scelerisque eu. Praesent at convallis urna, id cursus erat. Ut feugiat placerat magna, a rutrum magna ornare faucibus. Aenean sapien ligula, dictum eu purus in, dignissim ullamcorper nisl. Duis eu turpis eget nulla semper tincidunt a sit amet magna. Nulla ac consequat nunc. Nullam pharetra a tellus nec dapibus.</p>
+    <p>Praesent eu purus semper, ultricies neque eget, cursus tellus. Vivamus dictum nec nunc id lacinia. Morbi facilisis arcu non imperdiet fringilla. Sed et commodo mi, eget interdum odio. Donec efficitur, tortor molestie suscipit dapibus, magna tellus interdum velit, et pharetra erat nunc nec ex. Curabitur facilisis, nisl in euismod auctor, neque enim molestie risus, non fringilla augue dolor non ex. Fusce faucibus justo at cursus malesuada.</p>
+    <p>Sed tempor placerat commodo. Sed suscipit neque non hendrerit malesuada. Curabitur pellentesque accumsan eleifend. Sed congue et tellus eu luctus. Suspendisse potenti. Proin quis erat et dolor interdum fringilla ornare non mauris. Nunc convallis dictum sodales. Aliquam dictum sollicitudin leo, mollis porttitor libero ullamcorper luctus.</p>
+    <h2>I denne pakke finder du:</h2>
+    [Plukliste]
+    <h2>Retur</h2>
+    <p>Benytte returlabel til at sende dit gamle modem retur indenfor 14 dage</p>
+    <h3>Med venlig hilsen<br />Fyns Kabel TV</h3>
+</body>
+</html>

--- a/Case/templates/PRINT-OPSIGELSE.html
+++ b/Case/templates/PRINT-OPSIGELSE.html
@@ -1,0 +1,19 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Tak for denne gang</title>
+</head>
+<body>
+    <div class="Adresse">[Adresse]</div>
+    <h1>Tak for denne gang</h1>
+    <h2>Hej [Name]</h2>
+    <p>Vi er glade for at du have haft dig som kunde. Du meget velkommen tilbage. Vestibulum vitae elit metus. Aliquam porttitor dui eu dui gravida tincidunt. Maecenas auctor elit enim, sed fermentum ante scelerisque eu. Praesent at convallis urna, id cursus erat. Ut feugiat placerat magna, a rutrum magna ornare faucibus. Aenean sapien ligula, dictum eu purus in, dignissim ullamcorper nisl. Duis eu turpis eget nulla semper tincidunt a sit amet magna. Nulla ac consequat nunc. Nullam pharetra a tellus nec dapibus.</p>
+    <p>Praesent eu purus semper, ultricies neque eget, cursus tellus. Vivamus dictum nec nunc id lacinia. Morbi facilisis arcu non imperdiet fringilla. Sed et commodo mi, eget interdum odio. Donec efficitur, tortor molestie suscipit dapibus, magna tellus interdum velit, et pharetra erat nunc nec ex. Curabitur facilisis, nisl in euismod auctor, neque enim molestie risus, non fringilla augue dolor non ex. Fusce faucibus justo at cursus malesuada.</p>
+    <p>Sed tempor placerat commodo. Sed suscipit neque non hendrerit malesuada. Curabitur pellentesque accumsan eleifend. Sed congue et tellus eu luctus. Suspendisse potenti. Proin quis erat et dolor interdum fringilla ornare non mauris. Nunc convallis dictum sodales. Aliquam dictum sollicitudin leo, mollis porttitor libero ullamcorper luctus.</p>
+    <h2>Retur</h2>
+    <p>Benytte returlabel og medsendte kasse til at sende dit gamle modem retur indenfor 14 dage</p>
+    <h3>På gensyn<br />Fyns Kabel TV</h3>
+</body>
+</html>

--- a/Case/templates/PRINT-WELCOME.html
+++ b/Case/templates/PRINT-WELCOME.html
@@ -1,0 +1,19 @@
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title>Velkommen til FKTV</title>
+</head>
+<body>
+    <div class="Adresse">[Adresse]</div>
+    <h1>Velkommen til FKTV</h1>
+    <h2>Hej [Name]</h2>
+    <p>Vi er glade for at kunne sende TV-signal til dig. Håber du vil finde indholdet sem ligula, et rutrum arcu pulvinar a. Vestibulum vitae elit metus. Aliquam porttitor dui eu dui gravida tincidunt. Maecenas auctor elit enim, sed fermentum ante scelerisque eu. Praesent at convallis urna, id cursus erat. Ut feugiat placerat magna, a rutrum magna ornare faucibus. Aenean sapien ligula, dictum eu purus in, dignissim ullamcorper nisl. Duis eu turpis eget nulla semper tincidunt a sit amet magna. Nulla ac consequat nunc. Nullam pharetra a tellus nec dapibus.</p>
+    <p>Praesent eu purus semper, ultricies neque eget, cursus tellus. Vivamus dictum nec nunc id lacinia. Morbi facilisis arcu non imperdiet fringilla. Sed et commodo mi, eget interdum odio. Donec efficitur, tortor molestie suscipit dapibus, magna tellus interdum velit, et pharetra erat nunc nec ex. Curabitur facilisis, nisl in euismod auctor, neque enim molestie risus, non fringilla augue dolor non ex. Fusce faucibus justo at cursus malesuada.</p>
+    <p>Sed tempor placerat commodo. Sed suscipit neque non hendrerit malesuada. Curabitur pellentesque accumsan eleifend. Sed congue et tellus eu luctus. Suspendisse potenti. Proin quis erat et dolor interdum fringilla ornare non mauris. Nunc convallis dictum sodales. Aliquam dictum sollicitudin leo, mollis porttitor libero ullamcorper luctus.</p>
+    <h2>I denne pakke finder du:</h2>
+    [Plukliste]
+    <h3>Med venlig hilsen<br />Fyns Kabel TV</h3>
+</body>
+</html>


### PR DESCRIPTION
Da mange kunder har været usikre på hvad de skal med de tilsendte pakker, har medarbejdere fra kundeservice og teknisk service forfattet vejledninger, der kan sendes med pakkerne. Vejledningerne hører til forskellige pakker. Da vejledningerne løbende bliver opdateret, udskrives de ved efterspørgelse.
Der er indkøbt et system, der udskriver HTML-filer fra en mappe.
Der er sat [tags] ind i html’en som I skal udskifte før I gemmer HTML’en i udskriftsmappen

I skal opdatere programmet så det kan håndtere både pluk-varer og vejledninger. Ved vejledninger skal der sendes en HTMLen til udskriftsmappen (“print”).